### PR TITLE
Binding keyboard controls for Previous and Next

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -48,14 +48,15 @@ $(function () {
     $('#player').attr('src', app.iframeSrc);
   });
 
-  //keybinding for 'N' and 'P' keys
+  //keybinding for 'A' and 'D' keys
   $(document).keydown(function(e) {
+    console.log(e.which);
     switch(e.which) {
-      case 78: // N for next
-        $('#forward').click();
-        break;
-      case 80: // P for previous
+      case 65: // A for previous
         $('#back').click();
+        break;
+      case 68: // D for next
+        $('#forward').click();
         break;
       default: return; // exit this handler for other keys
     }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -47,4 +47,19 @@ $(function () {
       app.iframeSrc = setURL();
     $('#player').attr('src', app.iframeSrc);
   });
+
+  //keybinding for 'N' and 'P' keys
+  $(document).keydown(function(e) {
+    switch(e.which) {
+      case 78: // N for next
+        $('#forward').click();
+        break;
+      case 80: // P for previous
+        $('#back').click();
+        break;
+      default: return; // exit this handler for other keys
+    }
+    e.preventDefault(); // prevent the default action (scroll / move caret)
+  });
+
 });

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -50,7 +50,6 @@ $(function () {
 
   //keybinding for 'A' and 'D' keys
   $(document).keydown(function(e) {
-    console.log(e.which);
     switch(e.which) {
       case 65: // A for previous
         $('#back').click();


### PR DESCRIPTION
Added navigation support using the keys 'P' for previous and 'N' for next on the document body.

**Limitation:**
I am not able to bind keys over YouTube iframe; 
I will add `&enablejsapi=1` parameter to the YouTube video link and try to explore the [YouTube iFrame API](https://developers.google.com/youtube/iframe_api_reference) to try and bind these keys.